### PR TITLE
Upgrade to maven-shade-plugin 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is inspired by https://github.com/redbadger/shade which allows you to reloc
 
 Use this for project-level plugins:
 
-Put `[lein-uber-shade "0.1.0"]` into the `:plugins` vector of your project.clj.
+Put `[lein-uber-shade "0.1.2"]` into the `:plugins` vector of your project.clj.
 
 To build the uberjar with shaded classes/packages/dependencies:
 

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject lein-uber-shade "0.1.1"
+(defproject lein-uber-shade "0.1.2"
   :description "Lein plugin to relocate classes/packages within uberjars"
   :url "https://github.com/obohrer/lein-uberjar-shade"
   :license {:name "Eclipse Public License" :url "http://www.eclipse.org/legal/epl-v20.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.apache.maven.plugins/maven-shade-plugin "3.1.0"]]
+                 [org.apache.maven.plugins/maven-shade-plugin "3.2.2"]]
   :deploy-repositories [["releases"  {:sign-releases false :url "https://clojars.org"}]
                         ["snapshots" {:sign-releases false :url "https://clojars.org"}]]
   :eval-in-leiningen true)


### PR DESCRIPTION
I tried this on a local project with a huge Spark job uberjar, and hit the following exception.  Upgrading maven-shade-plugin fixed the problem for me.

```
  :uber-shade {:relocations [{:from com.google.common :to shaded.com.google.common}]}
```

```
java.lang.IllegalArgumentException: null
 at org.objectweb.asm.ClassReader.<init> (:-1)
    org.objectweb.asm.ClassReader.<init> (:-1)
    org.objectweb.asm.ClassReader.<init> (:-1)
    org.apache.maven.plugins.shade.DefaultShader.addRemappedClass (DefaultShader.java:427)
    org.apache.maven.plugins.shade.DefaultShader.shadeSingleJar (DefaultShader.java:229)
    org.apache.maven.plugins.shade.DefaultShader.shadeJars (DefaultShader.java:190)
    org.apache.maven.plugins.shade.DefaultShader.shade (DefaultShader.java:106)
    obohrer.uber_shade.core$shade.invokeStatic (core.clj:40)
```